### PR TITLE
Add executable xlsx_to_csv

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,8 +21,8 @@ For example, input filename is foo.csv then output filename is foo.xlsx.
   csv_to_xlsx input.csv output.xlsx
 
 === Excel xlsx to CSV:
-  csv_to_xlsx input.xlsx
-  csv_to_xlsx input.xlsx output.csv
+  xlsx_to_csv input.xlsx
+  xlsx_to_csv input.xlsx output.csv
 
 == Development
   # prepare repository

--- a/bin/xlsx_to_csv
+++ b/bin/xlsx_to_csv
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+# require the gem
+require 'csv_xlsx_converter'
+
+CsvXlsxConverter::main

--- a/csv-xlsx-converter.gemspec
+++ b/csv-xlsx-converter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.date = "2017-08-23"
   s.description = "Convert CSV to Excel xlsx, Excel xlsx to CSV.".freeze
   s.email = "libsora25@gmail.com".freeze
-  s.executables = ["csv_to_xlsx".freeze]
+  s.executables = ["csv_to_xlsx".freeze, "xlsx_to_csv".freeze]
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.rdoc"


### PR DESCRIPTION
I was confused to convert from xlsx to CSV with `csv_to_xlsx`.
I think that `xlsx_to_csv` is appropriate and added it.
I think this command should limit the file extension that can be converted, but I'm happy just to be able to use `xlsx_to_csv` for the time being.