### PR TITLE
Fix CsvToXlsx for ruby 3

### DIFF
--- a/lib/csv_xlsx_converter/converter.rb
+++ b/lib/csv_xlsx_converter/converter.rb
@@ -16,8 +16,7 @@ module CsvXlsxConverter
       workbook = RubyXL::Workbook.new
       worksheet = workbook[0]
 
-      options = {:encoding => 'bom|UTF-8', :skip_blanks => true}
-      CSV.foreach(@input_file, options).each_with_index do |row, row_idx|
+      CSV.foreach(@input_file, :encoding => 'bom|UTF-8', :skip_blanks => true).each_with_index do |row, row_idx|
         # http://stackoverflow.com/questions/12407035/ruby-csv-get-current-line-row-number
         row.each_with_index do |item, index|
           worksheet.add_cell row_idx, index, item


### PR DESCRIPTION
### Issue and solution
- Using this gem with ruby 3 is throwing below error when executing `CsvXlsxConverter::CsvToXlsx` (trying to convert `csv` to `xlsx`)
```ruby
Traceback (most recent call last):
       10: from /usr/local/bundle/bin/irb:25:in `<main>'
        9: from /usr/local/bundle/bin/irb:25:in `load'
        8: from /usr/local/bundle/gems/irb-1.1.1/exe/irb:11:in `<top (required)>'
        7: from (irb):2
        6: from /usr/local/bundle/gems/csv-xlsx-converter-0.0.3/lib/csv_xlsx_converter/converter.rb:20:in `convert'
        5: from /usr/local/bundle/gems/csv-xlsx-converter-0.0.3/lib/csv_xlsx_converter/converter.rb:20:in `each_with_index'
        4: from /usr/local/lib/ruby/3.0.0/csv.rb:1205:in `foreach'
        3: from /usr/local/lib/ruby/3.0.0/csv.rb:1421:in `open'
        2: from /usr/local/lib/ruby/3.0.0/csv.rb:1421:in `open'
        1: from /usr/local/lib/ruby/3.0.0/csv.rb:1421:in `initialize'
TypeError (no implicit conversion of Hash into String)
```
- This PR fixes the issue for ruby 3 and the solution still works perfectly with ruby 2 as it was